### PR TITLE
Support for unsigned requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Options:
   -l, --log                        log to file [default: fastlist_{datetime}.log]
       --endpoint <ENDPOINT>        custom S3 endpoint URL
       --force-path-style           force path-style addressing (default when using --endpoint)
+      --no-sign-request            do not sign requests, access bucket anonymously (--region is recommended)
   -h, --help                       Print help
   -V, --version                    Print version
 ```
@@ -84,6 +85,22 @@ s3-fast-list list --bucket my-bucket --force-path-style
 ```
 
 This changes the request URLs from virtual-hosted style (`https://my-bucket.s3.example.com/key`) to path style (`https://s3.example.com/my-bucket/key`).
+
+### Anonymous Access
+
+Publicly readable buckets, such as the [AWS Open Data](https://registry.opendata.aws/) datasets, can be listed without AWS credentials. Use `--no-sign-request` to skip credentials lookup and request signing, same as the AWS CLI option of the same name:
+
+```
+s3-fast-list --no-sign-request list --region us-east-1 --bucket noaa-normals-pds
+```
+
+Supplying `--region` is recommended. The flag does not change how the region is resolved, which still falls back to the environment or an AWS profile, and an unsigned run usually has neither.
+
+`ks-tool` accepts the same option. The manifest and every inventory file it references must be publicly readable, as both are fetched with the same unsigned client:
+
+```
+ks-tool inventory --no-sign-request -r {region} -m s3://{location_of_your_s3_inventory}.manifest.json
+```
 
 ### List mode
 ```

--- a/ks-tool/src/main.rs
+++ b/ks-tool/src/main.rs
@@ -47,7 +47,11 @@ enum Commands {
 
         /// max concurrency for download and process inventory files
         #[arg(short, long, default_value_t = 1)]
-        concurrency: usize
+        concurrency: usize,
+
+        /// do not sign requests, access inventory anonymously
+        #[arg(long)]
+        no_sign_request: bool
 
     },
 }
@@ -61,8 +65,8 @@ async fn main() -> Result<(), tokio::io::Error> {
         Commands::Split { ks, count, output } => {
             utils::handle_ks_input(ks, *count, &output).await?;
         },
-        Commands::Inventory { region, manifest, ks, concurrency } => {
-            utils::inventory_to_ks(region, manifest, ks.as_ref(), *concurrency).await?;
+        Commands::Inventory { region, manifest, ks, concurrency, no_sign_request } => {
+            utils::inventory_to_ks(region, manifest, ks.as_ref(), *concurrency, *no_sign_request).await?;
         },
     }
     Ok(())

--- a/ks-tool/src/utils.rs
+++ b/ks-tool/src/utils.rs
@@ -222,13 +222,18 @@ async fn build_and_dump_prefix_map(client: S3Client,
     Ok(())
 }
 
-pub(crate) async fn inventory_to_ks(region: &str, manifest: &str, ks: Option<&String>, max_concurrency: usize) -> Result<(), Error> {
+pub(crate) async fn inventory_to_ks(region: &str, manifest: &str, ks: Option<&String>, max_concurrency: usize, no_sign_request: bool) -> Result<(), Error> {
     let r = region.to_string();
     // build default client with region from params
-    let config = aws_config::from_env()
-        .region(aws_config::Region::new(r))
-        .load()
-        .await;
+    let mut loader = aws_config::from_env()
+        .region(aws_config::Region::new(r));
+
+    // skip credentials loading and request signing for anonymous access
+    if no_sign_request {
+        loader = loader.no_credentials();
+    }
+
+    let config = loader.load().await;
     let client = S3Client::new(&config);
     let tm = S3TransferManager::new(client.clone());
 

--- a/s3-fast-list/src/core.rs
+++ b/s3-fast-list/src/core.rs
@@ -641,11 +641,12 @@ pub(crate) struct S3TaskContext {
 
 impl S3TaskContext {
     pub fn new(bucket: &str, region: Option<&str>, endpoint: Option<&str>, force_path_style: bool,
+            no_sign_request: bool,
             data_map_channel: UnboundedSender<HashMap<ObjectPrefix, Vec<(ObjectName, ObjectProps)>>>,
             dir: u8, g_state: GlobalState) -> Self {
 
         // create and config s3 client
-        let loader = aws_config::from_env()
+        let mut loader = aws_config::from_env()
             .retry_config(
                 aws_config::retry::RetryConfig::standard()
                     .with_max_attempts(S3_CLIENT_MAX_ATTEMPTS)
@@ -656,6 +657,11 @@ impl S3TaskContext {
                     .connect_timeout(std::time::Duration::from_secs(S3_CLIENT_CONNECT_TIMEOUT))
                     .build()
             );
+
+        // skip credentials loading and request signing for anonymous access
+        if no_sign_request {
+            loader = loader.no_credentials();
+        }
 
         let config = tokio::task::block_in_place(move || {
             tokio::runtime::Handle::current()

--- a/s3-fast-list/src/main.rs
+++ b/s3-fast-list/src/main.rs
@@ -53,6 +53,10 @@ struct Cli {
     #[arg(long, global=true)]
     force_path_style: bool,
 
+    /// do not sign requests, access bucket anonymously (--region is recommended)
+    #[arg(long, global=true)]
+    no_sign_request: bool,
+
     /// log file path (implies --log) [default: fastlist_{datetime}.log]
     #[arg(long, global=true)]
     output_log_file: Option<String>,
@@ -141,6 +145,9 @@ fn main() {
 
     // Use path-style addressing if explicitly requested or if a custom endpoint is provided
     let opt_force_path_style = cli.force_path_style || opt_endpoint.is_some();
+
+    // access buckets anonymously, no credentials loading and no request signing
+    let opt_no_sign_request = cli.no_sign_request;
 
     // Extract output file options
     let opt_output_ks_file = cli.output_ks_file;
@@ -259,7 +266,7 @@ fn main() {
         };
         let task_ctx = core::S3TaskContext::new(opt_bucket,
             opt_region.as_ref().map(|s| s.as_str()), opt_endpoint.as_ref().map(|s| s.as_str()),
-            opt_force_path_style, data_map_channel.clone(), dir, g_state.clone()
+            opt_force_path_style, opt_no_sign_request, data_map_channel.clone(), dir, g_state.clone()
         );
         set.spawn_blocking(move || {
             tokio::runtime::Handle::current().block_on(async move {
@@ -278,7 +285,8 @@ fn main() {
 
             let task_ctx = core::S3TaskContext::new(opt_target_bucket.as_ref().unwrap(),
                 target_region_str, opt_endpoint.as_ref().map(|s| s.as_str()), opt_force_path_style,
-                data_map_channel, core::S3_TASK_CONTEXT_DIR_RIGHT_DIFF_MODE, g_state.clone()
+                opt_no_sign_request, data_map_channel, core::S3_TASK_CONTEXT_DIR_RIGHT_DIFF_MODE,
+                g_state.clone()
             );
             let ks_hints = data_map::KeySpaceHints::new_from(&ks_list);
             set.spawn_blocking(move || {


### PR DESCRIPTION
This PR adds support for `--no-sign-request` so that s3-fast-list can list anonymous S3 buckets.

I needed this when comparing `s3-fast-list` against other S3 listing tools as part of https://github.com/varveio/s3-listing-study
